### PR TITLE
typo

### DIFF
--- a/app/views/layouts/documentation.html.haml
+++ b/app/views/layouts/documentation.html.haml
@@ -13,7 +13,7 @@
         %h2 CTS
         %ul
           %li= link_to 'Arrêts bus et tram', documentation_page_path(id: 'cts/arrets')
-          %li= link_to 'Horraires en temps réel', documentation_page_path(id: 'cts/temps-reel')
+          %li= link_to 'Horaires en temps réel', documentation_page_path(id: 'cts/temps-reel')
         %h2 Parkings
         %ul
           %li


### PR DESCRIPTION
horaires ne prend qu'un seul 'r' ;-)
